### PR TITLE
pause on applying celery to django scrapy

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/3.0/ref/settings/
 """
 
 import os
+from celery.schedules import crontab
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -123,8 +124,16 @@ STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
 # celery
-CELERY_BROKER_URL = 'redis://localhost:6379'
-CELERY_RESULT_BACKEND = 'redis://localhost:6379'
-CELERY_ACCEPT_CONTENT = ['application/json']
-CELERY_RESULT_SERIALIZER = 'json'
-CELERY_TASK_SERIALIZER = 'json'
+# CELERY_BROKER_URL = 'redis://localhost:6379'
+# CELERY_RESULT_BACKEND = 'redis://localhost:6379'
+# CELERY_ACCEPT_CONTENT = ['application/json']
+# CELERY_RESULT_SERIALIZER = 'json'
+# CELERY_TASK_SERIALIZER = 'json'
+# CELERY_TIMEZONE = 'Asia/Tokyo'
+#
+# CELERY_BEAT_SCHEDULE = {
+#     "update-maradmins": {
+#         "task": "search_api.tasks.scrape_maradmins",
+#         "schedule": crontab(minute="*/1"),
+#     }
+# }

--- a/backend/maradmin_scrapy_project/maradmin_scrapy_project/settings.py
+++ b/backend/maradmin_scrapy_project/maradmin_scrapy_project/settings.py
@@ -37,7 +37,7 @@ ROBOTSTXT_OBEY = True
 # Configure a delay for requests for the same website (default: 0)
 # See https://docs.scrapy.org/en/latest/topics/settings.html#download-delay
 # See also autothrottle settings and docs
-#DOWNLOAD_DELAY = 3
+DOWNLOAD_DELAY = 1
 # The download delay setting will honor only one of:
 #CONCURRENT_REQUESTS_PER_DOMAIN = 16
 #CONCURRENT_REQUESTS_PER_IP = 16

--- a/backend/maradmin_scrapy_project/maradmin_scrapy_project/spiders/maradminspider.py
+++ b/backend/maradmin_scrapy_project/maradmin_scrapy_project/spiders/maradminspider.py
@@ -6,9 +6,9 @@ from search_api.models import Maradmin
 class MaradminSpider(scrapy.Spider):
     name = "maradminspider"
     start_urls = ["https://www.marines.mil/News/Messages/MARADMINS.aspx/?Page=1"]
+    Maradmin.objects.all().delete()
 
     def parse(self, response):
-        Maradmin.objects.all().delete()
 
         for item in response.css("div.item"):
             print('scraping item inside maradminspider')
@@ -20,7 +20,7 @@ class MaradminSpider(scrapy.Spider):
             insert_item["status"] = item.css(".msg-status.msg-col::text").extract_first()
             yield insert_item
 
-        max_counter = 25
+        max_counter = 51
         for num in range(2, max_counter):
             next_page_url = (
                 f"https://www.marines.mil/News/Messages/MARADMINS.aspx/?Page={num}"

--- a/backend/search_api/tasks.py
+++ b/backend/search_api/tasks.py
@@ -1,5 +1,42 @@
 from celery import shared_task
+from maradmin_scrapy_project.maradmin_scrapy_project.spiders.maradminspider import MaradminSpider
+from scrapy.utils.project import get_project_settings
+from scrapy.crawler import CrawlerProcess, CrawlerRunner
+from twisted.internet import reactor
+from multiprocessing import Process, Queue
+import scrapy
+
 
 @shared_task
-def adding_task(x,y):
-    return x+y
+def scrape_maradmins():
+    from crochet import setup
+    setup()
+    process = CrawlerRunner(get_project_settings())
+    d = process.crawl(MaradminSpider)
+    d.addBoth(lambda _: reactor.stop())
+    reactor.run()
+
+    # Runner
+    # def f(q):
+    #     try:
+    #         process = CrawlerRunner(get_project_settings())
+    #         d = process.crawl(MaradminSpider)
+    #         d.addBoth(lambda _: reactor.stop())
+    #         reactor.run()
+    #         q.put(None)
+    #     except Exception as e:
+    #         q.put(e)
+    # q = Queue()
+    # p = Process(target=f, args=(q,))
+    # p.start()
+    # result = q.get()
+    # p.join()
+    #
+    # if result is not None:
+    #     raise result
+
+
+    # Processor
+    # process = CrawlerProcess(get_project_settings())
+    # process.crawl(MaradminSpider)
+    # process.run()

--- a/backend/search_api/views.py
+++ b/backend/search_api/views.py
@@ -6,5 +6,5 @@ from .models import Maradmin
 
 
 class MaradminViewSet(viewsets.ModelViewSet):
-    queryset = Maradmin.objects.all().order_by("-date")[:5]
+    queryset = Maradmin.objects.all().order_by("-date")[:25]
     serializer_class = MaradminSerializer


### PR DESCRIPTION
celery does not play nice with django and scrapy because a scrapy command is suppose to run only once. There is a nasty bug. The workaround is to run the `scrapy crawl maradminspider` as a corn job establish outside of celery. Implementation will be done at a later time. 